### PR TITLE
Fixed cookie issue

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -22,10 +22,9 @@ export default function Layout({ title, description, children }) {
   const [darkMode, setDarkMode] = useState(false);
 
   useEffect(() => {
-      console.log(".....")
-    console.log(Cookies.get());
-    console.log(".....")
-    let currentMode = Boolean(Cookies.get('darkMode') || false);
+    // Check if browser contains cookie with name 'darkMode'. If it does, check if its value is 'true', if it is, 
+    // set currentMode to true, if not, set currentMode to false.  
+    let currentMode = /^true$/i.test(Cookies.get('darkMode'));
     setDarkMode(currentMode)
   }, [])
 
@@ -61,10 +60,7 @@ export default function Layout({ title, description, children }) {
    * @description
    */
   const darkModeChangeHandler = () => {
-    console.log(Cookies.get());
-    Cookies.remove('darkMode', { path: '' });
     Cookies.set('darkMode', !darkMode);
-    console.log(Cookies.get());
     setDarkMode(!darkMode);
   };
   return (


### PR DESCRIPTION
Added functionality that allows user's theme choice remain even after the user closes the browser page. The issue with the code was this line of code:
`let currentMode = Boolean(Cookies.get('darkMode') || false);`
`Boolean()` was returning true no matter what string got passed to it,

I changed that line of code to compare the string against a RegEx instead. 
`let currentMode = /^true$/i.test(Cookies.get('darkMode'));`
Worked like a charm